### PR TITLE
Skip state update when data is missing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,11 @@ class ElectroluxWellbeingPlatform implements DynamicPlatformPlugin {
       const { pncId } = accessory.context;
       const state = this.getApplianceState(pncId, data);
 
+      // Guard against missing data due to API request failure.
+      if (!state) {
+        return;
+      }
+
       // Keep firmware revision up-to-date in case the device is updated.
       accessory
         .getService(Service.AccessoryInformation)!


### PR DESCRIPTION
The API requests seem to fail intermittently, e.g.:

```
[8/10/2021, 4:36:41 PM] [ElectroluxWellbeing] Could not fetch appliances data: Error: read ECONNRESET
[8/10/2021, 6:15:41 PM] [ElectroluxWellbeing] Could not fetch appliances data: Error: read ECONNRESET
[8/10/2021, 8:54:42 PM] [ElectroluxWellbeing] Could not fetch appliances data: Error: Client network socket disconnected before secure TLS connection was established
```

This guard avoids updating HomeKit with empty data.

A better option might be to retry the request, maybe 1-3 times and perhaps using some sort of backoff.
